### PR TITLE
CALL-1571 Update metadata for Ecuador and added a test

### DIFF
--- a/build/data-patches/002-Ecuador-Metadata.patch
+++ b/build/data-patches/002-Ecuador-Metadata.patch
@@ -1,0 +1,16 @@
+diff --git a/resources/PhoneNumberMetadata.xml b/resources/PhoneNumberMetadata.xml
+index bb5ac108..1bfb4ba1 100644
+--- a/resources/PhoneNumberMetadata.xml
++++ b/resources/PhoneNumberMetadata.xml
+@@ -7010,9 +7010,8 @@
+             6(?:
+               [017-9]\d{2}|
+               2(?:
+-                [0-47-9]\d|
+-                5[1-9]|
+-                60
++                [0-46-9]\d|
++                5[1-9]
+               )|
+               30\d
+             )

--- a/src/data/PhoneNumberMetadata_EC.php
+++ b/src/data/PhoneNumberMetadata_EC.php
@@ -42,7 +42,7 @@ return array (
   ),
   'mobile' => 
   array (
-    'NationalNumberPattern' => '9(?:(?:39|[45][89]|7[7-9]|[89]\\d)\\d{2}|6(?:[017-9]\\d{2}|2(?:[0-47-9]\\d|5[1-9]|60)|30\\d))\\d{4}',
+    'NationalNumberPattern' => '9(?:(?:39|[45][89]|7[7-9]|[89]\\d)\\d{2}|6(?:[017-9]\\d{2}|2(?:[0-46-9]\\d|5[1-9])|30\\d))\\d{4}',
     'ExampleNumber' => '991234567',
     'PossibleLength' => 
     array (

--- a/tests/Issues/EcuadorMetadataTest.php
+++ b/tests/Issues/EcuadorMetadataTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace libphonenumber\Tests\Issues;
+
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+
+class ErrorMetadataTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var PhoneNumberUtil
+     */
+    public $phoneNumberUtil;
+
+    public function setUp()
+    {
+        PhoneNumberUtil::resetInstance();
+        $this->phoneNumberUtil = PhoneNumberUtil::getInstance();
+    }
+
+    public function testParseEcuadorNumberWithNewAcceptedPrefix()
+    {
+        $number = $this->phoneNumberUtil->parse('593962600575', 'EC');
+
+        $this->assertEquals("+593962600575", $this->phoneNumberUtil->format($number, PhoneNumberFormat::E164));
+    }
+}


### PR DESCRIPTION
Review with the metadata update for Ecuador allowing mobile numbers starting with 9626

This repo is a fork from https://github.com/giggsey/libphonenumber-for-php.

The regex used is `9(?:(?:39|[45][89]|7[7-9]|[89]\d)\d{2}|6(?:[017-9]\d{2}|2(?:[0-46-9]\d|5[1-9])|30\d))\d{4}`. 
His representation:
![image](https://user-images.githubusercontent.com/11631002/37479362-c98e196e-287c-11e8-81d2-d3e38fdeb7b5.png)

The previous one was `9(?:(?:39|[45][89]|7[7-9]|[89]\d)\d{2}|6(?:[017-9]\d{2}|2(?:[0-47-9]\d|5[1-9|60])|30\d))\d{4}`.
His representation:
![image 1](https://user-images.githubusercontent.com/11631002/37479426-eadba7f8-287c-11e8-8116-c904faa90cbe.png)

Another option suggested by @marcoscarceles is `9(?:(?:39|[45][89]|7[7-9]|[89]\d)\d{2}|6(?:[017-9]\d{2}|2(?:[0-46-9]\d|5[1-9|60])|30\d))\d{4}`, just change [0-47-9] to [0-46-9].
His representation:
![image 2](https://user-images.githubusercontent.com/11631002/37479511-1c369470-287d-11e8-9319-107fcab2a988.png)
Even that his representation is different, |60 shouldn't be needed, but up to you guys.

